### PR TITLE
dont clone data in navigateTo() but create a new element

### DIFF
--- a/project/static/js/spa.js
+++ b/project/static/js/spa.js
@@ -229,7 +229,14 @@ function unloadTitle() {
 // Function to navigate to a new URL
 function navigateTo(url, data = null) {
     try {
-        history.pushState(data, "", url);
+        let jsonData = null;
+        if (data) {
+            jsonData = {};
+            for (let pair of data.entries()) {
+                jsonData[pair[0]] = pair[1];
+            }
+        }
+        history.pushState(jsonData, "", url);
         spa(url, data);
     } catch (err) {
         console.error("Unable to load external resources from SPA:", err);


### PR DESCRIPTION
Fix navigateTo in Chrome